### PR TITLE
Add x-data-checker so flathubbot can update the project automatically

### DIFF
--- a/org.freecol.FreeCol.json
+++ b/org.freecol.FreeCol.json
@@ -70,7 +70,13 @@
           {
             "type": "archive",
             "url": "https://github.com/FreeCol/freecol/archive/nightly-2019-01-02.zip",
-            "sha256": "8f1daa1be356e078c7812f262f61d44543a6b2bd89f9a5344ac8ba9be2b195ab"
+            "sha256": "8f1daa1be356e078c7812f262f61d44543a6b2bd89f9a5344ac8ba9be2b195ab",
+            "x-checker-data": {
+              "type": "html",
+              "url": "https://www.freecol.org/download.html",
+              "version-pattern": "freecol-([\\d\\.-]*).zip",
+              "url-template": "https://github.com/FreeCol/freecol/archive/refs/tags/v$version.tar.gz"
+            }
           },
           {
             "type": "patch",


### PR DESCRIPTION
Somewhat related to #7 

Tested with org.flathub.flatpak-external-data-checker, relevant output:

```
$ flatpak run org.flathub.flatpak-external-data-checker org.freecol.FreeCol.json
INFO    src.manifest: Checking 2 external data items
INFO    src.manifest: Skipped check [1/2] archive imagemagick/ImageMagick-7.0.8-68.tar.xz (from org.freecol.FreeCol.json)
INFO    src.manifest: Started check [2/2] archive freecol/nightly-2019-01-02.zip (from org.freecol.FreeCol.json)
INFO    src.lib.externaldata: Source nightly-2019-01-02.zip: got new version 0.13.0
INFO    src.manifest: Finished check [2/2] archive freecol/nightly-2019-01-02.zip (from org.freecol.FreeCol.json)
OUTDATED: nightly-2019-01-02.zip
 Has a new version:
  URL:       https://github.com/FreeCol/freecol/archive/refs/tags/v0.13.0.tar.gz
  MD5:       3add4237219fe9d1e4d5c75859aa8cd0
  SHA1:      78b428e9debca7eeafff9db78dfc402a84098355
  SHA256:    d129a85f4b00cdc75e7d47ba58cdbeea1cdb4da71c81ef17fcf1abb2fff1cafb
  SHA512:    ef64a32e0fc16aaad44f83f80b838ec5c16eac0cb42b7698cb63310316b22823fb56f5e5ebb4deec487d0e4dad17b00bca11d52e81bb166f330939ffdb304bd7
  Size:      766837113
  Version:   0.13.0
  Timestamp: 2022-07-21 23:49:25

INFO    src.main: Check finished with 0 error(s)
```